### PR TITLE
feat: Make dashboard behavior configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,3 +4,7 @@ websites:
   - https://www.google.com
   - https://www.amazon.com
   - https://www.microsoft.com
+
+timeout_seconds: 5
+refresh_interval_seconds: 30
+max_history_length: 15


### PR DESCRIPTION
This commit introduces several configuration options to the website status dashboard, allowing you to customize its behavior via `config.yaml`.

The following parameters can now be set in `config.yaml`:

- `timeout_seconds`: Network timeout for website checks (default: 10s).
- `refresh_interval_seconds`: Interval between status check cycles (default: 60s).
- `max_history_length`: Number of past statuses to display per website (default: 20).

The `dashboard.py` script has been updated to read these values and use the specified defaults if a parameter is not found in the configuration file.

Additionally, `dashboard.py` was slightly refactored by moving `Console()` instantiation into a `main()` function to improve testability. Unit tests were drafted but encountered execution timeouts.